### PR TITLE
fix: day availability validation change

### DIFF
--- a/backend/resources/graphql/mutations.py
+++ b/backend/resources/graphql/mutations.py
@@ -140,6 +140,7 @@ class ResourceMutation:
             raise ValidationError(TIME_ERROR)
 
         if DayAvailability.objects.filter(
+            resource=resource,
             day=input.day,
             start_time__lt=input.end_time,
             end_time__gt=input.start_time,
@@ -168,6 +169,8 @@ class ResourceMutation:
     ) -> DayAvailabilityType:
         day_availability = DayAvailability.objects.get(id=input.day_availability_id)
 
+        resource = day_availability.resource
+
         updated_fields = {
             "start_time": input.start_time,
             "end_time": input.end_time,
@@ -178,6 +181,7 @@ class ResourceMutation:
 
         if DayAvailability.objects.filter(
             ~Q(id=input.day_availability_id),
+            resource=resource,
             day=day_availability.day,
             start_time__lt=input.end_time,
             end_time__gt=input.start_time,


### PR DESCRIPTION
## Description

In the validation of the creation of day availability, when checking if there was another availability at the same time, it was not verified that it was for the same resource. So when a day availability was created at the same time and day as another from another resource, the OVERLAP_ERROR occurred.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes (unit test cases covered). Provide instructions so we can reproduce if necessary. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
