### PR TITLE
fix: availabilities query change

### DIFF
--- a/backend/resources/graphql/inputs.py
+++ b/backend/resources/graphql/inputs.py
@@ -23,6 +23,7 @@ class DayAvailabilityInput:
 
 @strawberry.input
 class MonthInput:
+    resource_id: UUID
     month: int
     year: int
 

--- a/backend/resources/graphql/mutations.py
+++ b/backend/resources/graphql/mutations.py
@@ -140,6 +140,7 @@ class ResourceMutation:
             raise ValidationError(TIME_ERROR)
 
         if DayAvailability.objects.filter(
+            resource=resource,
             day=input.day,
             start_time__lt=input.end_time,
             end_time__gt=input.start_time,
@@ -168,6 +169,8 @@ class ResourceMutation:
     ) -> DayAvailabilityType:
         day_availability = DayAvailability.objects.get(id=input.day_availability_id)
 
+        resource = day_availability.resource
+
         updated_fields = {
             "start_time": input.start_time,
             "end_time": input.end_time,
@@ -178,6 +181,7 @@ class ResourceMutation:
 
         if DayAvailability.objects.filter(
             ~Q(id=input.day_availability_id),
+            resource=resource,
             day=day_availability.day,
             start_time__lt=input.end_time,
             end_time__gt=input.start_time,

--- a/backend/resources/graphql/queries.py
+++ b/backend/resources/graphql/queries.py
@@ -36,9 +36,9 @@ class ResourcesQuery:
         self, info: Info, input: MonthInput
     ) -> list[DayAvailabilityGroupType]:
         user = info.context.request.user
-        resources = Resource.objects.filter(user=user)
+        resource = Resource.objects.get(user=user, id=input.resource_id)
         query = DayAvailability.objects.filter(
-            resource__in=resources, day__year=input.year, day__month=input.month
+            resource=resource, day__year=input.year, day__month=input.month
         ).order_by("day", "start_time")
 
         availability_groups = defaultdict(list)

--- a/backend/resources/graphql/queries.py
+++ b/backend/resources/graphql/queries.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+
 import strawberry
 from strawberry.types import Info
 from strawberry_django_jwt.decorators import login_required
@@ -5,7 +7,7 @@ from strawberry_django_jwt.decorators import login_required
 from base.graphql.inputs import PaginationInput
 from base.graphql.utils import get_paginator
 from resources.graphql.inputs import MonthInput
-from resources.graphql.types import PaginatedDayAvailabilityType, PaginatedResourceType
+from resources.graphql.types import DayAvailabilityGroupType, PaginatedResourceType
 from resources.models import DayAvailability, Resource
 
 
@@ -31,16 +33,23 @@ class ResourcesQuery:
     @strawberry.field(description="Returns a list of your daily availabilities.")
     @login_required
     def my_daily_availability(
-        self, info: Info, input: MonthInput, pagination: PaginationInput | None = None
-    ) -> PaginatedDayAvailabilityType:
-        if pagination is None:
-            pagination = {}
+        self, info: Info, input: MonthInput
+    ) -> list[DayAvailabilityGroupType]:
         user = info.context.request.user
         resources = Resource.objects.filter(user=user)
         query = DayAvailability.objects.filter(
             resource__in=resources, day__year=input.year, day__month=input.month
         ).order_by("day", "start_time")
 
-        return get_paginator(
-            query, pagination.page_size, pagination.page, PaginatedDayAvailabilityType
-        )
+        availability_groups = defaultdict(list)
+        for availability in query:
+            availability_groups[availability.day].append(availability)
+
+        result = []
+        for day, availabilities in availability_groups.items():
+            day_availability_group = DayAvailabilityGroupType(
+                day=day, availabilities=availabilities
+            )
+            result.append(day_availability_group)
+
+        return result

--- a/backend/resources/graphql/types.py
+++ b/backend/resources/graphql/types.py
@@ -23,6 +23,7 @@ class ResourceType:
 class DayAvailabilityType:
     id: uuid.UUID
     resource: ResourceType
+    day: date
     start_time: time
     end_time: time
 

--- a/backend/resources/graphql/types.py
+++ b/backend/resources/graphql/types.py
@@ -23,16 +23,16 @@ class ResourceType:
 class DayAvailabilityType:
     id: uuid.UUID
     resource: ResourceType
-    day: date
     start_time: time
     end_time: time
 
 
 @strawberry.type
-class PaginatedResourceType(PaginatedQueryType):
-    edges: list[ResourceType]
+class DayAvailabilityGroupType:
+    day: date
+    availabilities: list[DayAvailabilityType]
 
 
 @strawberry.type
-class PaginatedDayAvailabilityType(PaginatedQueryType):
-    edges: list[DayAvailabilityType]
+class PaginatedResourceType(PaginatedQueryType):
+    edges: list[ResourceType]

--- a/backend/resources/tests/requests/queries.py
+++ b/backend/resources/tests/requests/queries.py
@@ -24,19 +24,10 @@ RESOURCES_ITEMS = """
 """
 
 DAY_AVAILABILITY_ITEMS = """
-    query($pagination: PaginationInput!, $input: MonthInput!){
-        myDailyAvailability(pagination: $pagination, input: $input){
-            pageInfo{
-                page
-                pages
-                totalResults
-            }
-            edges{
-                id
-                resource{
-                    name
-                }
-                day
+    query($input: MonthInput!){
+        myDailyAvailability(input: $input){
+            day
+            availabilities{
                 startTime
                 endTime
             }

--- a/backend/resources/tests/test_day_availability_queries.py
+++ b/backend/resources/tests/test_day_availability_queries.py
@@ -36,6 +36,7 @@ class TestResourcesQueries(TestBase):
 
         variables = {
             "input": {
+                "resourceId": resource.id,
                 "year": 2030,
                 "month": 2,
             },

--- a/backend/resources/tests/test_day_availability_queries.py
+++ b/backend/resources/tests/test_day_availability_queries.py
@@ -35,10 +35,6 @@ class TestResourcesQueries(TestBase):
         )
 
         variables = {
-            "pagination": {
-                "page": 1,
-                "pageSize": 5,
-            },
             "input": {
                 "year": 2030,
                 "month": 2,
@@ -50,42 +46,8 @@ class TestResourcesQueries(TestBase):
         )
 
         data = json.loads(response.content.decode())
-        print("DATA", data)
-        resources = data.get("data").get("myDailyAvailability").get("edges")
+        resources = data.get("data").get("myDailyAvailability")
         assert len(resources) == 2
 
         assert resources[0].get("day") == "2030-02-02"
-        assert resources[1].get("startTime") == "09:00:00"
-
-    def test_my_daily_availabilities_without_pagination(self):
-        resource = mixer.blend(Resource, user=self.user)
-        mixer.blend(
-            DayAvailability,
-            resource=resource,
-            day="2030-02-02",
-            start_time="09:00:00",
-            end_time="13:00:00",
-        )
-        mixer.blend(
-            DayAvailability,
-            resource=resource,
-            day="2030-02-10",
-            start_time="09:00:00",
-            end_time="14:00:00",
-        )
-        mixer.blend(
-            DayAvailability,
-            resource=resource,
-            day="2030-02-20",
-            start_time="08:00:00",
-            end_time="13:00:00",
-        )
-
-        variables = {}
-
-        response = self.post(
-            query=DAY_AVAILABILITY_ITEMS, user=self.user, variables=variables
-        )
-
-        data = json.loads(response.content.decode())
-        assert data.get("data") is None
+        assert resources[1].get("availabilities")[0].get("startTime") == "09:00:00"

--- a/backend/resources/tests/test_resources_mutations.py
+++ b/backend/resources/tests/test_resources_mutations.py
@@ -22,8 +22,8 @@ class TestResourcesMutations(TestBase):
                 "name": "test 1",
                 "description": "test 1 description",
                 "availableTime": 120,
-                "startDate": "2024-02-22",
-                "endDate": "2024-02-27",
+                "startDate": "2030-02-22",
+                "endDate": "2030-02-27",
                 "location": "Sevilla",
             }
         }
@@ -42,7 +42,7 @@ class TestResourcesMutations(TestBase):
                 "description": "test 1 description",
                 "availableTime": 120,
                 "startDate": "2022-02-22",
-                "endDate": "2024-02-27",
+                "endDate": "2030-02-27",
                 "location": "Sevilla",
             }
         }
@@ -57,8 +57,8 @@ class TestResourcesMutations(TestBase):
                 "name": "test 1",
                 "description": "test 1 description",
                 "availableTime": 120,
-                "startDate": "2024-02-22",
-                "endDate": "2024-02-20",
+                "startDate": "2030-02-22",
+                "endDate": "2030-02-20",
                 "location": "Sevilla",
             }
         }


### PR DESCRIPTION
## Description

Now each day returns all the availabilities created in the same object instead of having one object per day and availability. Change required for frontend implementation


## Type of change

- [ ] Refactor (neither fixes a bug nor adds a feature)
- [ ] Tests (adding missing and/or correcting existing tests)
- [ ] This change requires a documentation update


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes (unit test cases covered). Provide instructions so we can reproduce if necessary. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
