### PR TITLE
fix: update resource now ignores current resource for repeating fields

### DIFF
--- a/backend/resources/errors.py
+++ b/backend/resources/errors.py
@@ -2,7 +2,9 @@ DATE_ERROR = "The start date must be before the end date."
 EXISTING_RESOURCE = (
     "A resource with the same characteristics already exists for this user."
 )
-PAST_DATE = "The start date must be today or in the future."
+PAST_START_DATE = "The start date must be today or in the future."
+PAST_END_DATE = "The end date must be in the future."
+
 PERMISSION_ERROR = "Resource not found or you don't have permission to update it."
 
 TIME_ERROR = "The start time must be before the end time"


### PR DESCRIPTION
## Description
When updating the resource, it could not be left as it is without modifying resource fields, since the same one existed. Now the current resource is not taken into account when updating and the fields can be left as they are to continue the flow.

In addition, the date that is validated is end_date so that when updating, past dates are not entered.

## Type of change

- [ ] Refactor (neither fixes a bug nor adds a feature)
- [ ] Tests (adding missing and/or correcting existing tests)
- [ ] This change requires a documentation update


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes (unit test cases covered). Provide instructions so we can reproduce if necessary. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
